### PR TITLE
Parse component limit inputs as decimals

### DIFF
--- a/src/marketplace/common/utils.ts
+++ b/src/marketplace/common/utils.ts
@@ -7,17 +7,30 @@ import { translate } from '@/i18n';
 import { useUser } from '@/workspace/hooks';
 
 export const parseIntField = (value) => parseInt(value, 10) || 0;
+// Component limits can be fractional -- a storage tier measured in TiB may
+// be 0.1 -- so they get their own parser. parseIntField stays integer-only
+// for its other callers: node counts, vCPUs, prepaid durations. A trailing
+// separator is handed straight back, because react-final-form re-parses on
+// every keystroke and collapsing "0." to 0 makes a decimal point impossible
+// to type.
+export const parseNumberField = (value) => {
+  if (value === '' || value === null || value === undefined) return 0;
+  const text = String(value).replace(',', '.');
+  if (text.endsWith('.')) return text;
+  const parsed = parseFloat(text);
+  return Number.isFinite(parsed) ? parsed : 0;
+};
 export const formatIntField = (value) => (value ? value.toString() : 0);
 export const validateNonNegative = (value) =>
   value < 0 ? translate('Value should not be negative.') : undefined;
 
 export const maxAmount = (limit) => (value) =>
-  parseInt(value, 10) > parseInt(limit, 10)
+  parseFloat(value) > parseFloat(limit)
     ? translate('Value should not be greater than {limit}.', { limit })
     : undefined;
 
 export const minAmount = (limit) => (value) =>
-  parseInt(value, 10) < parseInt(limit, 10)
+  parseFloat(value) < parseFloat(limit)
     ? translate('Value should not be lesser than {limit}.', { limit })
     : undefined;
 

--- a/src/marketplace/details/plan/ComponentEditRow.tsx
+++ b/src/marketplace/details/plan/ComponentEditRow.tsx
@@ -5,7 +5,7 @@ import { PublicOfferingDetails, Offering } from 'waldur-js-client';
 
 import { AwesomeCheckbox } from '@/core/AwesomeCheckbox';
 import { composeValidators } from '@/core/validators';
-import { formatIntField, parseIntField } from '@/marketplace/common/utils';
+import { formatIntField, parseNumberField } from '@/marketplace/common/utils';
 import { getOfferingComponentValidator } from '@/marketplace/offerings/store/limits';
 
 import { ComponentRow, ComponentRow2 } from './ComponentRow';
@@ -39,6 +39,7 @@ const RowWrapper = (
     ) : (
       <Form.Control
         type="number"
+        step="any"
         min={props.offeringComponent.min_value || 0}
         max={props.offeringComponent.max_value}
         {...props.input}
@@ -57,7 +58,7 @@ export const ComponentEditRow: React.FC<ComponentEditRowProps> = (props) => {
   return (
     <Field
       name={`limits.${props.component.type}`}
-      parse={parseIntField}
+      parse={parseNumberField}
       format={formatIntField}
       validate={validateValue}
       component={RowWrapper}
@@ -109,7 +110,7 @@ export const ComponentEditRow2: React.FC<ComponentEditRowProps> = (props) => {
   return (
     <Field
       name={`limits.${props.component.type}`}
-      parse={parseIntField}
+      parse={parseNumberField}
       format={formatIntField}
       validate={validateValue}
       component={RowWrapper2}

--- a/src/marketplace/details/plan/MeasuredUnitInput.tsx
+++ b/src/marketplace/details/plan/MeasuredUnitInput.tsx
@@ -15,6 +15,7 @@ export const MeasuredUnitInput = ({
     <Form.Control
       name={input.name}
       type="number"
+      step="any"
       min={component.min_value || 0}
       max={component.max_value}
       aria-describedby={`basic-addon-${component.type}`}

--- a/src/marketplace/details/plan/TotalLimitComponentsTable.tsx
+++ b/src/marketplace/details/plan/TotalLimitComponentsTable.tsx
@@ -9,7 +9,7 @@ import { isFeatureVisible } from '@/features/connect';
 import { MarketplaceFeatures } from '@/FeaturesEnums';
 import { InputField } from '@/form/InputField';
 import { translate } from '@/i18n';
-import { formatIntField, parseIntField } from '@/marketplace/common/utils';
+import { formatIntField, parseNumberField } from '@/marketplace/common/utils';
 import { getOfferingComponentValidator } from '@/marketplace/offerings/store/limits';
 import { PriceTooltip } from '@/price/PriceTooltip';
 import { renderFieldOrDash } from '@/table/utils';
@@ -64,7 +64,7 @@ export const TotalLimitComponentsTable: FunctionComponent<
                 ) : (
                   <Field
                     name={`limits.${component.type}`}
-                    parse={parseIntField}
+                    parse={parseNumberField}
                     format={formatIntField}
                     validate={validateValue}
                   >
@@ -73,6 +73,7 @@ export const TotalLimitComponentsTable: FunctionComponent<
                         input={input}
                         meta={meta}
                         type="number"
+                        step="any"
                         className="px-2"
                       />
                     )}

--- a/src/marketplace/resources/change-limits/ComponentRow.tsx
+++ b/src/marketplace/resources/change-limits/ComponentRow.tsx
@@ -6,7 +6,7 @@ import { AwesomeCheckbox } from '@/core/AwesomeCheckbox';
 import { composeValidators } from '@/core/validators';
 import { NumberField } from '@/form';
 import { Limits } from '@/marketplace/common/types';
-import { parseIntField, formatIntField } from '@/marketplace/common/utils';
+import { parseNumberField, formatIntField } from '@/marketplace/common/utils';
 import { getResourceComponentValidator } from '@/marketplace/offerings/store/limits';
 import { ChangedLimitField } from '@/marketplace/resources/change-limits/ChangedLimitField';
 import { PriceField } from '@/marketplace/resources/change-limits/PriceField';
@@ -37,6 +37,7 @@ const CellWrapper: FC<any> = (props) => (
         unit={props.offeringComponent.measured_unit}
         min={props.limits.min}
         max={props.limits.max}
+        step="any"
       />
     )}
   </Form.Group>
@@ -55,7 +56,7 @@ export const ComponentRow: FC<ComponentRowProps> = ({
       <td>{renderFieldOrDash(component.limit)}</td>
       <FinalFormField
         name={`${parentName ? parentName + '.' : ''}limits.${component.type}`}
-        parse={parseIntField}
+        parse={parseNumberField}
         format={formatIntField}
         validate={composeValidators(...getResourceComponentValidator(limits))}
         min={0}


### PR DESCRIPTION
## Problem

Every component limit input parses with `parseIntField`, so a fractional limit cannot be typed at all — `parseInt("0.1")` is `0`, and because `react-final-form` re-parses on each keystroke the decimal point disappears as it is typed. The inputs are also bare `<input type="number">`, which defaults to `step=1`, so the browser rejects a fractional value before React sees it.

This matters for storage components measured in TiB, where a sub-TiB allocation is legitimate: a free-tier quota of 0.1 TiB has no integer representation. Today such a limit can be set by an operator through the provider `set_limits` action, but never requested or edited in the UI — and if a user opens the change-limits dialog on such a resource, the field collapses to `0` on the first keystroke.

## Change

`parseNumberField` is added **alongside** `parseIntField` rather than replacing it. `parseIntField` has around twenty other callers — Rancher node counts, VMware vCPUs, prepaid durations — that must stay whole, so only the four editable `limits.<type>` inputs switch over:

- `details/plan/ComponentEditRow.tsx` (both `ComponentEditRow` and `ComponentEditRow2`)
- `details/plan/TotalLimitComponentsTable.tsx`
- `resources/change-limits/ComponentRow.tsx`

`step="any"` is added to those inputs plus `details/plan/MeasuredUnitInput.tsx`.

A trailing separator is returned untouched, so `"0."` survives long enough for the next keystroke. `formatIntField` needs no change — it already renders a float correctly. `minAmount`/`maxAmount` move to `parseFloat`, a no-op for integer input.

`resources/reallocate-limits/ComponentRow.tsx` is deliberately left alone to keep the diff to the ordering and limit-change paths.

## Verified

Parser behaviour:

```
""->0   "0"->0   "0."->"0."   "0.1"->0.1   "0,1"->0.1   "2"->2   "abc"->0   null->0
typing 0.1: 0 -> "0." -> 0.1
```

Built and run against 8.1.2 in a test deployment: the order form accepts a typed `0.1`, the order reaches `done`, and the resource stores `{"cpu": 2000, "storage_project": 0.1, "storage_scratch": 2}` — whole numbers still `int`, only the fraction a float.

## Requires the API half

`waldur/waldur-mastermind` — every limit serializer is `DictField(child=IntegerField())`, so without that change these widened inputs are rejected server-side with "A valid integer is required". The two are only useful together; the mastermind PR link follows in a comment.

Licensing: I agree to license this contribution under the MIT license.
